### PR TITLE
EPMRPP-116480 || Rename plugin_id -> integration_type for Create org request

### DIFF
--- a/api/openapi/apis/organizations.yaml
+++ b/api/openapi/apis/organizations.yaml
@@ -1510,9 +1510,9 @@ components:
         name:
           type: string
           description: Integration name.
-        plugin_id:
+        integration_type:
           type: string
-          description: Plugin identifier for the integration.
+          description: Integration type information.
         enabled:
           type: boolean
           description: Whether the integration is enabled.

--- a/api/openapi/reportportal-api.yaml
+++ b/api/openapi/reportportal-api.yaml
@@ -3646,9 +3646,9 @@ components:
         name:
           type: string
           description: Integration name.
-        plugin_id:
+        integration_type:
           type: string
-          description: Plugin identifier for the integration.
+          description: Integration type information.
         enabled:
           type: boolean
           description: Whether the integration is enabled.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Updates**
  * Updated the organization integration creation endpoint to use `integration_type` parameter instead of `plugin_id` for specifying integration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->